### PR TITLE
media-tv/plex-media-server: update LICENSE

### DIFF
--- a/media-tv/plex-media-server/files/README.gentoo
+++ b/media-tv/plex-media-server/files/README.gentoo
@@ -8,3 +8,7 @@ You will then be able to access your library at http://localhost:32400/manage
 If installing on a remote host you will need to use a ssh tunnel eg,
 'ssh ip.address.of.server -L 8888:localhost:32400' then open the folowing in
 a local browser 'http://localhost:8888/web' to claim the remote server.
+
+Finally, please note usage of the plex-media-server is governed by a license
+grant detailed in their terms of service which can be reviewed at:
+https://www.plex.tv/about/privacy-legal/plex-terms-of-service/

--- a/media-tv/plex-media-server/plex-media-server-1.41.7.9799.ebuild
+++ b/media-tv/plex-media-server/plex-media-server-1.41.7.9799.ebuild
@@ -18,7 +18,7 @@ SRC_URI="
 "
 S="${WORKDIR}"
 
-LICENSE="Plex"
+LICENSE="all-rights-reserved"
 SLOT="0"
 KEYWORDS="-* amd64 arm arm64 x86"
 RESTRICT="mirror bindist"

--- a/media-tv/plex-media-server/plex-media-server-1.41.7.9823.ebuild
+++ b/media-tv/plex-media-server/plex-media-server-1.41.7.9823.ebuild
@@ -18,7 +18,7 @@ SRC_URI="
 "
 S="${WORKDIR}"
 
-LICENSE="Plex"
+LICENSE="all-rights-reserved"
 SLOT="0"
 KEYWORDS="-* amd64 arm arm64 x86"
 RESTRICT="mirror bindist"

--- a/media-tv/plex-media-server/plex-media-server-1.41.8.9834.ebuild
+++ b/media-tv/plex-media-server/plex-media-server-1.41.8.9834.ebuild
@@ -18,7 +18,7 @@ SRC_URI="
 "
 S="${WORKDIR}"
 
-LICENSE="Plex"
+LICENSE="all-rights-reserved"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm ~arm64 ~x86"
 RESTRICT="mirror bindist"


### PR DESCRIPTION
Align with ::gentoo, the copy of the Plex license was out of date. Now follow what other 'clickwrap' apps do and use all-rights-reserved.

This also updates the readme to include a link to the ToS.